### PR TITLE
Prevent multiple calls to initializeChatInstance on first render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aismarttalk/react-hooks",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aismarttalk/react-hooks",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aismarttalk/react-hooks",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## 📦 Merge Request Description

### 🔧 What was fixed

* Resolved the issue where `initializeChatInstance()` was called twice on page load by using `useRef` instead of `useState` for guards.
* This eliminates the side effect introduced by React 18’s `StrictMode` during development.

### 🧠 Technical Context

* React’s `useEffect` is invoked twice under `StrictMode` in development mode to help catch bugs.
* `useState` updates are asynchronous and can’t be used to prevent parallel invocations in this context.
* Refs (`useRef`) are used instead to track `isChanging` and `hasInitialized` reliably across renders without triggering re-renders.

### 📌 Changes

* Refactored `initializeChatInstance()` and `useEffect()` to use `useRef`-based flags
* Logs now confirm only a single call to the API endpoint on initial render

